### PR TITLE
fix(svg): ignore an `<svg>` tag inside an XML comment

### DIFF
--- a/src/types/svg.ts
+++ b/src/types/svg.ts
@@ -8,10 +8,44 @@ type IAttributes = {
 };
 
 const svgReg = /<svg\s([^"'>]|"[^"]*"|'[^']*')*>/;
+const svgRegGlobal = new RegExp(svgReg.source, "g");
+
+const COMMENT_OPEN = "<!--";
+const COMMENT_CLOSE = "-->";
+
+/**
+ * Match the root `<svg>` tag, skipping any tag that sits inside an XML comment.
+ *
+ * Editors and export tools routinely leave a commented-out `<svg …>` above the
+ * real one. Comments cannot nest, so a tag is commented out when the nearest
+ * preceding `<!--` has no `-->` between it and the tag.
+ */
+function matchRootTag(svg: string): string | undefined {
+  svgRegGlobal.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = svgRegGlobal.exec(svg)) !== null) {
+    const commentStart = svg.lastIndexOf(COMMENT_OPEN, match.index);
+    if (commentStart === -1) {
+      return match[0];
+    }
+    const commentEnd = svg.indexOf(
+      COMMENT_CLOSE,
+      commentStart + COMMENT_OPEN.length,
+    );
+    if (commentEnd === -1) {
+      // Unterminated comment: everything from here on is commented out.
+      return undefined;
+    }
+    if (commentEnd > match.index) {
+      svgRegGlobal.lastIndex = commentEnd + COMMENT_CLOSE.length;
+      continue;
+    }
+    return match[0];
+  }
+}
 
 const extractorRegExps = {
   height: /\sheight=(["'])([^%]+?)\1/,
-  root: svgReg,
   viewbox: /\sviewbox=(["'])(.+?)\1/i,
   width: /\swidth=(["'])([^%]+?)\1/,
 };
@@ -92,9 +126,9 @@ export const SVG: IImage = {
   validate: (input) => svgReg.test(toUTF8String(input, 0, 1000)),
 
   calculate(input) {
-    const root = toUTF8String(input).match(extractorRegExps.root);
+    const root = matchRootTag(toUTF8String(input));
     if (root) {
-      const attrs = parseAttributes(root[0]);
+      const attrs = parseAttributes(root);
       if (attrs.width && attrs.height) {
         return calculateByDimensions(attrs);
       }

--- a/test/fixtures/invalid/svg/only-commented-root.svg
+++ b/test/fixtures/invalid/svg/only-commented-root.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- <svg xmlns="http://www.w3.org/2000/svg" width="123px" height="456px"></svg> -->

--- a/test/fixtures/valid/svg/commented-root-multiline.svg
+++ b/test/fixtures/valid/svg/commented-root-multiline.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Multi-line editor leftover.
+  <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+  </svg>
+-->
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg"
+   width="123px" height="456px">
+</svg>

--- a/test/fixtures/valid/svg/commented-root-multiline.svg.meta
+++ b/test/fixtures/valid/svg/commented-root-multiline.svg.meta
@@ -1,0 +1,5 @@
+{
+  "height": 456,
+  "type": "svg",
+  "width": 123,
+}

--- a/test/fixtures/valid/svg/commented-root.svg
+++ b/test/fixtures/valid/svg/commented-root.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="1px" height="1px"></svg> -->
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg"
+   width="123px" height="456px">
+</svg>

--- a/test/fixtures/valid/svg/commented-root.svg.meta
+++ b/test/fixtures/valid/svg/commented-root.svg.meta
@@ -1,0 +1,5 @@
+{
+  "height": 456,
+  "type": "svg",
+  "width": 123,
+}


### PR DESCRIPTION
### Problem

The SVG root tag is matched with a single non-global regex, so the **first** `<svg …>` in the file wins — including one inside an XML comment. A commented-out root left above the real one is a routine editor and export-tool leftover, and its dimensions are silently reported for the image.

```js
const real = '<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400"></svg>'

imageMeta(enc(real))
// { width: 600, height: 400, type: 'svg' }   correct

imageMeta(enc(`<!-- <svg width="1" height="1"></svg> -->\n${real}`))
// { width: 1, height: 1, type: 'svg' }       from the commented-out tag
```

No error is raised — the caller gets a plausible but wrong size. This is the mechanism behind the "add a comment and it works" workaround reported in unjs/ipx#287, where the reported dimensions happen to come from a commented-out line.

### Fix

Scan forward over root-tag matches and skip any whose nearest preceding `<!--` has no `-->` before it. Comments cannot nest, so that check is exact. When every tag in the file is commented out, no root is found and the existing `Invalid SVG` `TypeError` is thrown.

`validate` is deliberately left alone: it still detects the file as SVG. Rejecting it there would turn a wrong-size bug into a wrong-format bug, and the 1 kB fast path shouldn't carry comment logic.

### Tests

Three fixtures, following the existing 123×456 convention:

| fixture | asserts |
|---|---|
| `valid/svg/commented-root.svg` | single-line commented root is skipped |
| `valid/svg/commented-root-multiline.svg` | multi-line comment block is skipped |
| `invalid/svg/only-commented-root.svg` | a file with *only* a commented root still throws |

All three fail on `main` and pass with the fix.

### Validation

- `pnpm test` → 64 passed (lint + `tsc` types + vitest with coverage)
- `pnpm build` → clean
- `src/types/svg.ts` coverage 96.4% statements / 93.1% branches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected SVG parsing when commented-out `<svg>` tags appear before the actual root element.
  * Improved handling of multiline and unterminated XML comments to identify the correct SVG root.

* **Tests**
  * Added coverage for SVG files containing commented root tags, including multiline comment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->